### PR TITLE
Add package rule for graphql-java(-*)

### DIFF
--- a/default.json
+++ b/default.json
@@ -46,6 +46,14 @@
         "minor"
       ],
       "automerge": false
+    },
+    {
+      "description": "Avoid attempts to upgrade to non-release tags such as v230521",
+      "matchPackageNames": [
+        "com.graphql-java:graphql-java",
+        "com.graphql-java:graphql-java-extended-scalars"
+      ],
+      "versioning": "semver-coerced"
     }
   ]
 }


### PR DESCRIPTION
To avoid the following: https://github.com/entur/deneir/pull/62

Already tested on uttu

semver-coerced is because X.Y isn't strictly semver, but can be treated as MAJOR.MINOR/PATCH