### PR TITLE
Include org.apache.camel packages in rule

### DIFF
--- a/default.json
+++ b/default.json
@@ -29,7 +29,8 @@
     {
       "description": "Do not automerge Camel minor releases (not SemVer compliant: breaking changes may occur)",
       "matchPackageNames": [
-        "org.apache.camel.springboot:camel-spring-boot-bom"
+        "org.apache.camel.springboot:camel-spring-boot-bom",
+        "org.apache.camel:*"
       ],
       "matchUpdateTypes": [
         "major",


### PR DESCRIPTION
I think we need to include org.apache.camel packages, because some dependencies are not available under the springboot group. E.g. https://github.com/entur/nibiru/pull/15