### PR TITLE
Remove hardcoded baseBranch: master

### DIFF
--- a/default.json
+++ b/default.json
@@ -44,7 +44,6 @@
     "regexManagers:dockerfileVersions"
   ],
   "platformAutomerge": false,
-  "baseBranch": "master",
   "enabledManagers": ["maven", "npm", "circleci", "dockerfile", "gradle", "gradle-wrapper", "pip", "github-actions", "helm-values"],
   "rangeStrategy": "pin",
   "commitMessageExtra" : "from v{{currentVersion}} to {{#if isMajor}}v{{{newMajor}}}{{else}}{{#if isSingleVersion}}v{{{toVersion}}}{{else}}{{{newValue}}}{{/if}}{{/if}}",


### PR DESCRIPTION
## Remove hardcoded `baseBranch: master`

This preset hardcodes `"baseBranch": "master"`. On repositories whose default
branch is `main`, that points Renovate at a branch that doesn't exist, so
Renovate silently does nothing unless the consuming repo adds its own
`baseBranch: main` override.

Impact today:
- **nunamnir** and **sobek** extend this preset on `main` with no override — their Renovate is currently a no-op.
- ~10 other `main`-based repos work only because each carries a redundant `baseBranch` override.

Removing the line makes Renovate fall back to each repository's **actual default
branch**, which is the desired behaviour for every consumer:
- `master`-default repos are unaffected (default branch is still `master`).
- `main`-default repos start working without a per-repo override.

This unblocks harmonizing the remaining outlier repos onto this shared config
without each needing a `baseBranch` workaround.
