### PR TITLE
Modernize shared Renovate config: follow default branch + automerge non-major after cooldown

### DIFF
--- a/default.json
+++ b/default.json
@@ -44,7 +44,6 @@
     "regexManagers:dockerfileVersions"
   ],
   "platformAutomerge": false,
-  "baseBranch": "master",
   "enabledManagers": ["maven", "npm", "circleci", "dockerfile", "gradle", "gradle-wrapper", "pip", "github-actions", "helm-values"],
   "rangeStrategy": "pin",
   "commitMessageExtra" : "from v{{currentVersion}} to {{#if isMajor}}v{{{newMajor}}}{{else}}{{#if isSingleVersion}}v{{{toVersion}}}{{else}}{{{newValue}}}{{/if}}{{/if}}",

--- a/default.json
+++ b/default.json
@@ -41,9 +41,12 @@
     "group:springWebflow",
     "group:springWs",
     "group:symfony",
-    "regexManagers:dockerfileVersions"
+    "regexManagers:dockerfileVersions",
+    "group:allNonMajor",
+    "schedule:weekly"
   ],
-  "platformAutomerge": false,
+  "timezone": "Europe/Oslo",
+  "platformAutomerge": true,
   "enabledManagers": ["maven", "npm", "circleci", "dockerfile", "gradle", "gradle-wrapper", "pip", "github-actions", "helm-values"],
   "rangeStrategy": "pin",
   "commitMessageExtra" : "from v{{currentVersion}} to {{#if isMajor}}v{{{newMajor}}}{{else}}{{#if isSingleVersion}}v{{{toVersion}}}{{else}}{{{newValue}}}{{/if}}{{/if}}",
@@ -72,6 +75,16 @@
     {
       "matchPackageNames": ["org.sonatype.plugins:nexus-staging-maven-plugin"],
       "enabled": false
+    },
+    {
+      "description": "Automerge non-major updates once the release-age cooldown has passed",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "description": "Major updates always require manual review",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
     },
     {
       "description": "Do not automerge Camel minor releases (not SemVer compliant: breaking changes may occur)",
@@ -119,20 +132,13 @@
       "versioning": "loose"
     },
     {
-      "description": "Require 4-day release age and disable automerge for all packages",
-      "minimumReleaseAge": "4 days",
-      "automerge": false
+      "description": "Require a 4-day release-age cooldown for all packages before updating",
+      "minimumReleaseAge": "4 days"
     },
     {
-      "description": "Exempt Entur-published packages from release age requirement",
+      "description": "Exempt Entur-published packages from the release-age cooldown (automerged immediately via the non-major rule above)",
       "matchPackagePatterns": ["^@entur/", "^org\\.entur", "^org\\.rutebanken"],
       "minimumReleaseAge": "0 days"
-    },
-    {
-      "description": "Allow automerge for non-major Entur package updates",
-      "matchPackagePatterns": ["^@entur/", "^org\\.entur", "^org\\.rutebanken"],
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true
     },
     {
       "description": "google/cloud-sdk does not follow semver, automerge all updates (cooldown still applies)",


### PR DESCRIPTION
## Modernize the shared Renovate config

Three related changes to `default.json`.

### 1. Follow each repo's default branch (remove hardcoded `baseBranch: master`)
The preset hardcoded `"baseBranch": "master"`, which on `main`-based repos points Renovate at a branch that doesn't exist — so Renovate silently no-ops unless the consumer adds its own `baseBranch: main` override. **nunamnir** and **sobek** are broken by this today; ~10 other repos only work because they carry a redundant override. Removing the line makes Renovate use each repository's actual default branch (`master` repos unaffected; `main` repos start working with no override).

### 2. Automerge non-major updates once the cooldown passes
Today the preset disables automerge for everything (only Entur packages + `google/cloud-sdk` automerge). This flips the default so third-party **minor/patch/pin/digest** updates automerge **after the existing 4-day release-age cooldown**:

| Update | automerge | cooldown |
|---|---|---|
| third-party minor/patch | ✅ | 4 days |
| **major (anything)** | ❌ manual review | 4 days |
| Camel / Logback minor (non-SemVer) | ❌ manual | preserved |
| Entur-published minor/patch | ✅ | 0 days |
| google/cloud-sdk | ✅ | 4 days |

Majors get an explicit manual-review rule; the non-SemVer carve-outs (Camel, Logback) are kept and still win; the old Entur-specific automerge rule is removed (subsumed by the global non-major rule, its 0-day cooldown exemption stays).

### 3. Merge `groupNonMajorWeekly` into the default
Adds `group:allNonMajor` + `schedule:weekly` + `timezone: Europe/Oslo`, so non-major updates land as a **single weekly PR** for every consumer. `groupNonMajorWeekly.json` is kept for backward compatibility (now a no-op on top of the default).

### ⚠️ Worth a sanity check before merge
- **`platformAutomerge` flipped `false` → `true`** — GitHub-native auto-merge is the standard way to make automerge work through branch protection / required checks. Revert this one line to keep the old behaviour.
- Automerge still only happens where each repo's **branch protection permits it**; this preset enables the intent, per-repo rules have the final say.
- `schedule:weekly` now applies to **all** consumers, not just the 4 that previously opted in.

_Supersedes the separate baseBranch-only PR._


---
### Dependent harmonization PRs
These migrate the remaining outlier repos onto this shared config; they assume this PR is merged first:
- entur/anshar#243
- entur/osrm-backend-docker#130
- entur/rutebanken-helpers#386
- entur/superpom#249
- entur/nunamnir#33

_`sobek` needs no PR — this change alone fixes its `main→master` targeting. `OpenTripPlanner` is intentionally excluded (bespoke upstream config)._