### PR TITLE
Exempt pin updates from the release-age cooldown

### DIFF
--- a/default.json
+++ b/default.json
@@ -141,6 +141,11 @@
       "minimumReleaseAge": "0 days"
     },
     {
+      "description": "Pins introduce no new code (they pin a range to an already-resolved version), so no release-age cooldown. Renovate re-creates renovate/stability-days on every rebase, which resets the clock — on active repos pins never cool down and stay stuck pending.",
+      "matchUpdateTypes": ["pin", "pinDigest"],
+      "minimumReleaseAge": "0 days"
+    },
+    {
       "description": "google/cloud-sdk does not follow semver, automerge all updates (cooldown still applies)",
       "matchPackageNames": ["google/cloud-sdk"],
       "automerge": true


### PR DESCRIPTION
## Exempt pin updates from the release-age cooldown

**Problem:** "Pin dependencies" PRs get stuck pending forever. Across the team ~20 of them are 20–55+ days old but their `renovate/stability-days` check is still *pending*, so they're never mergeable and never auto-merge.

**Cause:** Renovate re-creates the `renovate/stability-days` status on a **fresh commit every time it rebases** the branch, which restarts the 4-day clock from zero. On active repos the base branch changes constantly → Renovate rebases → the cooldown never completes. (Verified live: triggering a rebase on `nabu#628` — a 59-day-old pin PR — re-created its stability check at `pending` with a brand-new timestamp.)

**Fix:** Pinning introduces no new code — it pins a range to a version already resolved / in use — so a release-age cooldown adds zero safety and only causes this reset loop. This exempts `pin`/`pinDigest` from `minimumReleaseAge`, matching the existing pattern used for Entur-published packages.

Once merged, the stuck pin PRs' stability checks go green on the next Renovate run, become mergeable, and (since the config already automerges non-major pins) drain on their own.
