### PR TITLE
Use Renovate's own automerge instead of GitHub native (platformAutomerge: false)

### DIFF
--- a/default.json
+++ b/default.json
@@ -46,7 +46,7 @@
     "schedule:weekly"
   ],
   "timezone": "Europe/Oslo",
-  "platformAutomerge": true,
+  "platformAutomerge": false,
   "enabledManagers": ["maven", "npm", "circleci", "dockerfile", "gradle", "gradle-wrapper", "pip", "github-actions", "helm-values"],
   "rangeStrategy": "pin",
   "commitMessageExtra" : "from v{{currentVersion}} to {{#if isMajor}}v{{{newMajor}}}{{else}}{{#if isSingleVersion}}v{{{toVersion}}}{{else}}{{{newValue}}}{{/if}}{{/if}}",


### PR DESCRIPTION
## Use Renovate's own automerge instead of GitHub native (`platformAutomerge: false`)

**Problem:** automerge-after-cooldown never actually fires. Cooled, green, mergeable PRs sit unmerged across the fleet (e.g. `nabu#628`).

**Cause:** `platformAutomerge: true` delegates merging to GitHub's **native auto-merge**, which requires each repo to have **both**:
1. `Allow auto-merge` enabled — currently **off on every repo sampled** (0/15), and
2. branch protection with a **required status check** — GitHub refuses to enable auto-merge on a PR that's already mergeable, so repos without required checks can't use it at all.

Branch protection is inconsistent across the ~40 repos, so native auto-merge is a non-starter without a large per-repo standardization effort.

**Fix:** switch to Renovate's own automerge. It needs **no repo-side config** — Renovate merges via the API (as `renovate[bot]`, so `on: push` CD/deploy still triggers with secrets) once its own green check passes. The only remaining blocker is a required **review**, which blocks native auto-merge too.

**Trade-off:** merges happen on Renovate's run cadence rather than the instant checks pass. Acceptable for dependency PRs.

After this merges, the cooled backlog (and the pins freed by #13) start merging as Renovate cycles through.
